### PR TITLE
重构和一些遗留功能性问题的解决

### DIFF
--- a/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
@@ -71,8 +71,6 @@ export class AdvancedColorPanelComponent implements OnInit {
       width: panel.offsetWidth,
       height: panel.offsetHeight
     }
-    // HACK: 这里计算offsetleft的时候把自己的高度也算进去了，不知道为什么
-    this.panel.top -= this.panel.height
   }
 
   initPointerPosition() {

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
@@ -43,6 +43,12 @@ export class AdvancedColorPanelComponent implements OnInit {
         this.getColor()
       }
     )
+    this.colorPickerService.onRootMouseMove.subscribe(
+      (event) => this.mouseMove(event)
+    )
+    this.colorPickerService.onRootMouseUp.subscribe(
+      () => this.mouseUp()
+    )
   }
 
   ngOnInit() {

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
@@ -27,9 +27,12 @@ export class AdvancedColorPanelComponent implements OnInit {
     private colorPickerService: ColorPickerService
   ) {
     this.colorPickerService.updateColor.subscribe(
-      () => {
-        this.color = this.colorPickerService.getColor();
-        this.getPureColor()
+      (setter) => {
+        if (setter === 'colorInput') {
+          this.color = this.colorPickerService.getColor();
+          this.getPureColor()
+          this.initPanel()
+        }
       }
     )
     this.colorPickerService.updatePureColor.subscribe(
@@ -108,7 +111,6 @@ export class AdvancedColorPanelComponent implements OnInit {
 
   getColor() {
     this.color = getColorByPosition(this.pureColor, this.pointer.left/this.panel.width, this.pointer.top/this.panel.height)
-    this.getPureColor()
     this.colorPickerService.setColor(this.color)
   }
 

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit, SimpleChanges } from '@angular/core';
-import { Input, Output, EventEmitter } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { colorToPureColor, getColorByPosition, getColorPosition } from '../../../shared/utils/color';
+import { ColorPickerService } from '../../services/color-picker.service';
 
 @Component({
   selector: 'd-advanced-color-panel',
@@ -8,9 +8,8 @@ import { colorToPureColor, getColorByPosition, getColorPosition } from '../../..
   styleUrls: ['./advanced-color-panel.component.scss']
 })
 export class AdvancedColorPanelComponent implements OnInit {
-  @Input() color;
-  @Input() pureColor;
-  @Output() send = new EventEmitter();
+  color: string;
+  pureColor: string;
   panel = {
     top: 0,
     left: 0,
@@ -24,20 +23,27 @@ export class AdvancedColorPanelComponent implements OnInit {
   }
   dragging: boolean = false;
 
-  constructor() { }
-
-  ngOnInit() {
-    this.getPureColor()
-    this.initPanel()
+  constructor(
+    private colorPickerService: ColorPickerService
+  ) {
+    this.colorPickerService.updateColor.subscribe(
+      () => {
+        this.color = this.colorPickerService.getColor();
+        this.getPureColor()
+      }
+    )
+    this.colorPickerService.updatePureColor.subscribe(
+      () => {
+        this.pureColor = this.colorPickerService.getPureColor()
+        this.getColor()
+      }
+    )
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.pureColor && (changes.pureColor.previousValue != changes.pureColor.currentValue)) {
-      // To resolve the ExpressionChangedAfterItHasBeenCheckedError
-      setTimeout(() => {
-        this.getColor()
-      }, 100);
-    }
+  ngOnInit() {
+    this.color = this.colorPickerService.getColor();
+    this.getPureColor()
+    this.initPanel()
   }
 
   getPureColor() {
@@ -102,7 +108,8 @@ export class AdvancedColorPanelComponent implements OnInit {
 
   getColor() {
     this.color = getColorByPosition(this.pureColor, this.pointer.left/this.panel.width, this.pointer.top/this.panel.height)
-    this.send.emit(this.color)
+    this.getPureColor()
+    this.colorPickerService.setColor(this.color)
   }
 
   mouseUp() {

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
@@ -31,7 +31,7 @@ export class AdvancedColorPanelComponent implements OnInit {
         if (setter === 'colorInput') {
           this.color = this.colorPickerService.getColor();
           this.getPureColor()
-          this.initPanel()
+          this.initPointerPosition()
         }
       }
     )
@@ -47,6 +47,7 @@ export class AdvancedColorPanelComponent implements OnInit {
     this.color = this.colorPickerService.getColor();
     this.getPureColor()
     this.initPanel()
+    this.initPointerPosition()
   }
 
   getPureColor() {
@@ -72,7 +73,9 @@ export class AdvancedColorPanelComponent implements OnInit {
     }
     // HACK: 这里计算offsetleft的时候把自己的高度也算进去了，不知道为什么
     this.panel.top -= this.panel.height
-    // init pointer position
+  }
+
+  initPointerPosition() {
     var position = getColorPosition(this.color)
     this.pointer.left = position.x * this.panel.width
     this.pointer.top = position.y * this.panel.height

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color-panel/advanced-color-panel.component.ts
@@ -30,6 +30,8 @@ export class AdvancedColorPanelComponent implements OnInit {
       (setter) => {
         if (setter === 'colorInput') {
           this.color = this.colorPickerService.getColor();
+          if (this.color === '') // input cleared color
+            return
           this.getPureColor()
           this.initPointerPosition()
         }
@@ -45,6 +47,9 @@ export class AdvancedColorPanelComponent implements OnInit {
 
   ngOnInit() {
     this.color = this.colorPickerService.getColor();
+    if (this.color === '') { // make red as default
+      this.color = '#ff0000'
+    }
     this.getPureColor()
     this.initPanel()
     this.initPointerPosition()

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color.component.html
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color.component.html
@@ -1,11 +1,6 @@
 <div class="advanced-color">
   <d-advanced-color-panel
-    [color]="color"
-    [pureColor]="pureColor"
-    (send)="receiveColor($event)"
   ></d-advanced-color-panel>
   <d-color-slider
-    [color]="color"
-    (send)="receivePureColor($event)"
   ></d-color-slider>
 </div>

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color.component.html
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color.component.html
@@ -1,6 +1,4 @@
 <div class="advanced-color">
-  <d-advanced-color-panel
-  ></d-advanced-color-panel>
-  <d-color-slider
-  ></d-color-slider>
+  <d-advanced-color-panel></d-advanced-color-panel>
+  <d-color-slider></d-color-slider>
 </div>

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color.component.scss
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color.component.scss
@@ -1,4 +1,5 @@
 .advanced-color {
     width: 100%;
     height: 130px;
+    user-select: none;
 }

--- a/ng-devui-plus/color-picker/advanced-color/advanced-color.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/advanced-color.component.ts
@@ -1,23 +1,27 @@
 import { Component, OnInit } from '@angular/core';
-import { Input, Output, EventEmitter } from '@angular/core';
+import { ColorPickerService } from '../services/color-picker.service';
 
 @Component({
-  selector: 'app-advanced-color',
+  selector: 'd-advanced-color',
   templateUrl: './advanced-color.component.html',
   styleUrls: ['./advanced-color.component.scss']
 })
 export class AdvancedColorComponent implements OnInit {
-  @Input() color;
-  @Output() send = new EventEmitter();
+  color: string;
   pureColor: string;
 
-  constructor() { }
-
-  ngOnInit() {
+  constructor(
+    private colorPickerService: ColorPickerService
+  ) {
+    this.colorPickerService.updateColor.subscribe(
+      () => {
+        this.color = this.colorPickerService.getColor()
+      }
+    )
   }
 
-  receiveColor(color) {
-    this.send.emit(color)
+  ngOnInit() {
+    this.color = this.colorPickerService.getColor();
   }
 
   receivePureColor(pureColor) {

--- a/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
@@ -24,9 +24,11 @@ export class ColorSliderComponent implements OnInit {
     private colorPickerService: ColorPickerService
   ) {
     this.colorPickerService.updateColor.subscribe(
-      () => {
-        this.color = this.colorPickerService.getColor()
-        this.initPanel()
+      (setter) => {
+        if (setter === 'colorInput') {
+          this.color = this.colorPickerService.getColor()
+          this.initPanel()
+        }
       }
     )
   }

--- a/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
@@ -33,6 +33,12 @@ export class ColorSliderComponent implements OnInit {
         }
       }
     )
+    this.colorPickerService.onRootMouseMove.subscribe(
+      (event) => this.mouseMove(event)
+    )
+    this.colorPickerService.onRootMouseUp.subscribe(
+      () => this.mouseUp()
+    )
   }
 
   ngOnInit() {

--- a/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
@@ -27,6 +27,8 @@ export class ColorSliderComponent implements OnInit {
       (setter) => {
         if (setter === 'colorInput') {
           this.color = this.colorPickerService.getColor()
+          if (this.color === '') // input cleared color
+            return
           this.initPointerPosition()
         }
       }
@@ -35,6 +37,9 @@ export class ColorSliderComponent implements OnInit {
 
   ngOnInit() {
     this.color = this.colorPickerService.getColor();
+    if (this.color === '') { // make red as default
+      this.color = '#ff0000'
+    }
     this.initPanel()
     this.initPointerPosition()
   }

--- a/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
@@ -27,7 +27,7 @@ export class ColorSliderComponent implements OnInit {
       (setter) => {
         if (setter === 'colorInput') {
           this.color = this.colorPickerService.getColor()
-          this.initPanel()
+          this.initPointerPosition()
         }
       }
     )
@@ -36,6 +36,7 @@ export class ColorSliderComponent implements OnInit {
   ngOnInit() {
     this.color = this.colorPickerService.getColor();
     this.initPanel()
+    this.initPointerPosition()
   }
 
   initPanel() {
@@ -53,15 +54,17 @@ export class ColorSliderComponent implements OnInit {
       top,
       height: panel.offsetHeight
     }
-    // init pointer position
+    // HACK: 这里计算offsetleft的时候把自己的高度也算进去了，不知道为什么
+    this.panel.top -= this.panel.height
+  }
+
+  initPointerPosition() {
     var position = getPointerPositionInSliderByColor(colorToPureColor(this.color))
     this.pointer.top = position * this.panel.height
   }
 
   mouseClick(event: MouseEvent) {
     this.pointer.top = event.clientY - this.panel.top
-    // HACK: sometimes the top minus the height, sometimes not
-    this.pointer.top = (this.pointer.top + this.panel.height) % this.panel.height
     this.getPureColor()
   }
 
@@ -73,8 +76,6 @@ export class ColorSliderComponent implements OnInit {
     if (!this.dragging)
       return
     this.pointer.top = event.clientY - this.panel.top
-    // HACK: sometimes the top minus the height, sometimes not
-    this.pointer.top = (this.pointer.top + this.panel.height) % this.panel.height
     // Edge detection
     if (this.pointer.top < 0) {
       this.pointer.top = 0

--- a/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
+++ b/ng-devui-plus/color-picker/advanced-color/color-slider/color-slider.component.ts
@@ -54,8 +54,6 @@ export class ColorSliderComponent implements OnInit {
       top,
       height: panel.offsetHeight
     }
-    // HACK: 这里计算offsetleft的时候把自己的高度也算进去了，不知道为什么
-    this.panel.top -= this.panel.height
   }
 
   initPointerPosition() {

--- a/ng-devui-plus/color-picker/basic-color/basic-color.component.html
+++ b/ng-devui-plus/color-picker/basic-color/basic-color.component.html
@@ -2,5 +2,5 @@
   [size]="20"
   [color]="color"
   *ngFor="let color of basicColors"
-  (click)="sendColor(color)"
+  (click)="clickColor(color)"
 ></d-color-cube>

--- a/ng-devui-plus/color-picker/basic-color/basic-color.component.ts
+++ b/ng-devui-plus/color-picker/basic-color/basic-color.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Input,Output,EventEmitter } from '@angular/core';
+import { Input } from '@angular/core';
+import { ColorPickerService } from '../services/color-picker.service';
 
 @Component({
   selector: 'd-basic-color',
@@ -8,12 +9,15 @@ import { Input,Output,EventEmitter } from '@angular/core';
 })
 export class BasicColorComponent implements OnInit {
   @Input() basicColors;
-  @Output() send = new EventEmitter();
-  constructor() { }
+
+  constructor(
+    private colorPickerService: ColorPickerService
+  ) { }
 
   ngOnInit() {
   }
-  sendColor(color) {
-    this.send.emit(color);
+
+  clickColor(color) {
+    this.colorPickerService.setColor(color);
   }
 }

--- a/ng-devui-plus/color-picker/color-input/color-input.component.ts
+++ b/ng-devui-plus/color-picker/color-input/color-input.component.ts
@@ -27,7 +27,7 @@ export class ColorInputComponent implements OnInit {
 
   inputChange() {
     if (this.checkColor())
-      this.colorPickerService.setColor(this.color)
+      this.colorPickerService.setColor(this.color, 'colorInput')
   }
 
   doConfirm() {

--- a/ng-devui-plus/color-picker/color-input/color-input.component.ts
+++ b/ng-devui-plus/color-picker/color-input/color-input.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Input, Output, EventEmitter } from '@angular/core';
+import { Output, EventEmitter } from '@angular/core';
+import { ColorPickerService } from '../services/color-picker.service';
 
 @Component({
   selector: 'd-color-input',
@@ -7,18 +8,26 @@ import { Input, Output, EventEmitter } from '@angular/core';
   styleUrls: ['./color-input.component.scss']
 })
 export class ColorInputComponent implements OnInit {
-  @Input() color;
-  @Output() send = new EventEmitter();
+  color: string;
   @Output() confirm = new EventEmitter();
 
-  constructor() { }
+  constructor(
+    private colorPickerService: ColorPickerService
+  ) {
+    this.colorPickerService.updateColor.subscribe(
+      () => {
+        this.color = this.colorPickerService.getColor()
+      }
+    )
+  }
 
   ngOnInit() {
+    this.color = this.colorPickerService.getColor();
   }
 
   inputChange() {
     if (this.checkColor())
-      this.send.emit(this.color)
+      this.colorPickerService.setColor(this.color)
   }
 
   doConfirm() {
@@ -27,7 +36,7 @@ export class ColorInputComponent implements OnInit {
   }
 
   checkColor() {
-    var re = /^|#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/
-    return re.test(this.color)
+    var re = /^#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})$/
+    return re.test(this.color) || this.color.length == 0
   }
 }

--- a/ng-devui-plus/color-picker/color-picker.component.html
+++ b/ng-devui-plus/color-picker/color-picker.component.html
@@ -1,10 +1,8 @@
 <div class="container" *ngIf="!hide">
   <div class="cancel-mask" (click)="cancel.emit()"></div>
   <div class="color-picker">
-    <d-recent-color #recentColor
-      [color]="color"
+    <d-recent-color
       [limit]="8"
-      (send)="receiveColor($event)"
       (confirm)="doConfirm($event)"
     ></d-recent-color>
     <div class="color-panel">
@@ -15,22 +13,16 @@
       </div>
       <div class="color-cubes" *ngIf="'basic' === selectedPanel"> 
         <d-basic-color
-          [basicColors]="basicColors" 
-          (send)="receiveColor($event)"
+          [basicColors]="basicColors"
         ></d-basic-color>
       </div>
       <div *ngIf="'more' === selectedPanel">
-        <app-advanced-color
-          [color]="color"
-          (send)="receiveColor($event)"
-        ></app-advanced-color>
+        <d-advanced-color></d-advanced-color>
       </div>
     </div>
     <hr>
     <d-color-input
-      [color]="color"
       (confirm)="doConfirm($event)"
-      (send)="receiveColor($event)"
     ></d-color-input>
   </div>
 </div>

--- a/ng-devui-plus/color-picker/color-picker.component.html
+++ b/ng-devui-plus/color-picker/color-picker.component.html
@@ -1,6 +1,10 @@
 <div class="container" *ngIf="!hide">
   <div class="cancel-mask" (click)="cancel.emit()"></div>
-  <div class="color-picker">
+  <div class="color-picker" 
+    (mousemove)="mouseMove($event)"
+    (mouseup)="mouseUp()"
+    (mouseleave)="mouseUp()"
+  >
     <d-recent-color
       [limit]="8"
       (confirm)="doConfirm($event)"

--- a/ng-devui-plus/color-picker/color-picker.component.html
+++ b/ng-devui-plus/color-picker/color-picker.component.html
@@ -11,13 +11,13 @@
         |
         <span [class.selected]="'more' === selectedPanel" (click)="selectPanel('more')">更多颜色</span>
       </div>
+      <div *ngIf="'more' === selectedPanel">
+        <d-advanced-color></d-advanced-color>
+      </div>
       <div class="color-cubes" *ngIf="'basic' === selectedPanel"> 
         <d-basic-color
           [basicColors]="basicColors"
         ></d-basic-color>
-      </div>
-      <div *ngIf="'more' === selectedPanel">
-        <d-advanced-color></d-advanced-color>
       </div>
     </div>
     <hr>

--- a/ng-devui-plus/color-picker/color-picker.component.ts
+++ b/ng-devui-plus/color-picker/color-picker.component.ts
@@ -14,7 +14,6 @@ export class ColorPickerComponent implements OnInit {
   @Output() confirm = new EventEmitter();
   @ViewChild('recentColor') recentColor: RecentColorComponent;
   selectedPanel: string = 'basic';
-  recentlyUsed: Array<string> = ['#fff'];
   basicColors: Array<string> = ["#ffffff", "#ffd7d5", "#ffdaa9", "#fffed5", "#d4fa00", "#73fcd6", "#a5c8ff", "#ffacd5", "#ff7faa", "#d6d6d6", "#ffacaa", "#ffb995", "#fffb00", "#73fa79", "#00fcff", "#78acfe", "#d84fa9", "#ff4f79", "#b2b2b2", "#d7aba9", "#ff6827", "#ffda51", "#00d100", "#00d5ff", "#0080ff", "#ac39ff", "#ff2941", "#888888", "#7a4442", "#ff4c00", "#ffa900", "#3da742", "#3daad6", "#0052ff", "#7a4fd6", "#d92142", "#000000", "#7b0c00", "#ff4c41", "#d6a841", "#407600", "#007aaa", "#021eaa", "#797baa", "#ab1942"];
 
   constructor() { }
@@ -38,9 +37,5 @@ export class ColorPickerComponent implements OnInit {
   doConfirm() {
     this.recentColor.saveRecentlyUsed()
     this.confirm.emit(this.color)
-  }
-
-  doColorChange(color) {
-    this.setColor(color)
   }
 }

--- a/ng-devui-plus/color-picker/color-picker.component.ts
+++ b/ng-devui-plus/color-picker/color-picker.component.ts
@@ -1,5 +1,5 @@
-import { Component, Input, Output, EventEmitter, OnInit, ViewChild } from '@angular/core';
-import { RecentColorComponent } from './recent-color/recent-color.component'
+import { Component, Input, Output, EventEmitter, OnInit } from '@angular/core';
+import { ColorPickerService } from './services/color-picker.service';
 
 @Component({
   selector: 'd-color-picker',
@@ -12,30 +12,35 @@ export class ColorPickerComponent implements OnInit {
   @Output() cancel = new EventEmitter();
   @Output() send = new EventEmitter();
   @Output() confirm = new EventEmitter();
-  @ViewChild('recentColor') recentColor: RecentColorComponent;
   selectedPanel: string = 'basic';
   basicColors: Array<string> = ["#ffffff", "#ffd7d5", "#ffdaa9", "#fffed5", "#d4fa00", "#73fcd6", "#a5c8ff", "#ffacd5", "#ff7faa", "#d6d6d6", "#ffacaa", "#ffb995", "#fffb00", "#73fa79", "#00fcff", "#78acfe", "#d84fa9", "#ff4f79", "#b2b2b2", "#d7aba9", "#ff6827", "#ffda51", "#00d100", "#00d5ff", "#0080ff", "#ac39ff", "#ff2941", "#888888", "#7a4442", "#ff4c00", "#ffa900", "#3da742", "#3daad6", "#0052ff", "#7a4fd6", "#d92142", "#000000", "#7b0c00", "#ff4c41", "#d6a841", "#407600", "#007aaa", "#021eaa", "#797baa", "#ab1942"];
 
-  constructor() { }
+  constructor(
+    private colorPickerService: ColorPickerService
+  ) {
+    this.colorPickerService.updateColor.subscribe(
+      () => {
+        this.color = this.colorPickerService.getColor()
+        this.send.emit(this.color)
+      }
+    )
+  }
 
   ngOnInit() {
+    this.colorPickerService.setColor(this.color)
   }
 
   selectPanel(panel) {    
     this.selectedPanel = panel
   }
 
-  setColor(color) {
-    this.color = color
-    this.send.emit(this.color)
-  }
-
   receiveColor(color) {
-    this.setColor(color)
+    this.colorPickerService.setColor(color)
+    this.send.emit(this.color)
   }
   
   doConfirm() {
-    this.recentColor.saveRecentlyUsed()
+    this.colorPickerService.saveRecentColor.emit()
     this.confirm.emit(this.color)
   }
 }

--- a/ng-devui-plus/color-picker/color-picker.component.ts
+++ b/ng-devui-plus/color-picker/color-picker.component.ts
@@ -34,6 +34,14 @@ export class ColorPickerComponent implements OnInit {
     this.selectedPanel = panel
   }
 
+  mouseMove(event: MouseEvent) {
+    this.colorPickerService.onRootMouseMove.emit(event)
+  }
+
+  mouseUp() {
+    this.colorPickerService.onRootMouseUp.emit()
+  }
+  
   doConfirm() {
     this.colorPickerService.saveRecentColor.emit()
     this.confirm.emit(this.color)

--- a/ng-devui-plus/color-picker/color-picker.component.ts
+++ b/ng-devui-plus/color-picker/color-picker.component.ts
@@ -34,11 +34,6 @@ export class ColorPickerComponent implements OnInit {
     this.selectedPanel = panel
   }
 
-  receiveColor(color) {
-    this.colorPickerService.setColor(color)
-    this.send.emit(this.color)
-  }
-  
   doConfirm() {
     this.colorPickerService.saveRecentColor.emit()
     this.confirm.emit(this.color)

--- a/ng-devui-plus/color-picker/color-picker.module.ts
+++ b/ng-devui-plus/color-picker/color-picker.module.ts
@@ -10,6 +10,7 @@ import { DevUIModule } from 'ng-devui';
 import { FormsModule } from '@angular/forms';
 import { BasicColorComponent } from './basic-color/basic-color.component';
 import { RecentColorComponent } from './recent-color/recent-color.component';
+import { ColorPickerService } from './services/color-picker.service';
 
 @NgModule({
     imports: [
@@ -37,7 +38,9 @@ import { RecentColorComponent } from './recent-color/recent-color.component';
         BasicColorComponent,
         RecentColorComponent,
     ],
-    providers: [],
+    providers: [
+        ColorPickerService,
+    ],
 })
 export class ColorPickerModule {
 }

--- a/ng-devui-plus/color-picker/recent-color/recent-color.component.ts
+++ b/ng-devui-plus/color-picker/recent-color/recent-color.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Input,Output,EventEmitter } from '@angular/core';
 import { saveRecentColors } from '../../shared/utils';
+import { ColorPickerService } from '../services/color-picker.service';
 
 @Component({
   selector: 'd-recent-color',
@@ -8,16 +9,29 @@ import { saveRecentColors } from '../../shared/utils';
   styleUrls: ['./recent-color.component.scss']
 })
 export class RecentColorComponent implements OnInit {
-  @Input() color;
+  color: string;
   @Input() limit: number;
-  @Output() send = new EventEmitter();
   @Output() confirm = new EventEmitter();
-  recentlyUsed: Array<string> = ['#fff'];
+  recentlyUsed: Array<string> = [];
 
-  constructor() { }
+  constructor(
+    private colorPickerService: ColorPickerService
+  ) {
+    this.colorPickerService.updateColor.subscribe(
+      () => {
+        this.color = this.colorPickerService.getColor()
+      }
+    )
+    this.colorPickerService.saveRecentColor.subscribe(
+      () => {
+        this.saveRecentlyUsed()
+      }
+    )
+  }
 
   ngOnInit() {
     this.loadFromLocalData()
+    this.color = this.colorPickerService.getColor();
   }
   
   loadFromLocalData() {
@@ -34,13 +48,12 @@ export class RecentColorComponent implements OnInit {
   }
 
   clearColor() {
-    this.send.emit('')
+    this.colorPickerService.setColor('')
   }
 
   doConfirm(color) {
-    this.color = color
+    this.colorPickerService.setColor(color)
     this.saveRecentlyUsed()
-    this.send.emit(color)
     this.confirm.emit()
   }
 }

--- a/ng-devui-plus/color-picker/services/color-picker.service.ts
+++ b/ng-devui-plus/color-picker/services/color-picker.service.ts
@@ -8,6 +8,8 @@ export class ColorPickerService {
   updateColor = new EventEmitter<string>();
   updatePureColor = new EventEmitter<void>();
   saveRecentColor = new EventEmitter<void>();
+  onRootMouseMove = new EventEmitter<MouseEvent>();
+  onRootMouseUp = new EventEmitter<void>();
 
   constructor() { }
 

--- a/ng-devui-plus/color-picker/services/color-picker.service.ts
+++ b/ng-devui-plus/color-picker/services/color-picker.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { EventEmitter } from '@angular/core';
+
+@Injectable()
+export class ColorPickerService {
+  color: string = '';
+  pureColor: string = '#ff0000';
+  updateColor = new EventEmitter<void>();
+  updatePureColor = new EventEmitter<void>();
+  saveRecentColor = new EventEmitter<void>();
+
+  constructor() { }
+
+  getColor() {
+    return this.color;
+  }
+
+  getPureColor() {
+    return this.pureColor;
+  }
+
+  setColor(color) {
+    var changed = this.color !== color
+    this.color = color;
+    if (changed)
+      this.updateColor.emit();
+  }
+
+  setPureColor(color) {
+    var changed = this.pureColor !== color
+    this.pureColor = color;
+    if (changed)
+      this.updatePureColor.emit();
+  }
+}

--- a/ng-devui-plus/color-picker/services/color-picker.service.ts
+++ b/ng-devui-plus/color-picker/services/color-picker.service.ts
@@ -19,18 +19,17 @@ export class ColorPickerService {
     return this.pureColor;
   }
 
-  // setter is who set the color, default as ''
   setColor(color, setter: string = 'normal') {
-    var changed = this.color !== color
+    var oldColor = this.color
     this.color = color;
-    if (changed)
-      this.updateColor.emit(setter);
+    if (oldColor !== color)
+      this.updateColor.emit(setter); // setter is who set the color
   }
 
   setPureColor(color) {
-    var changed = this.pureColor !== color
+    var oldColor = this.pureColor
     this.pureColor = color;
-    if (changed)
+    if (oldColor !== color)
       this.updatePureColor.emit();
   }
 }

--- a/ng-devui-plus/color-picker/services/color-picker.service.ts
+++ b/ng-devui-plus/color-picker/services/color-picker.service.ts
@@ -5,7 +5,7 @@ import { EventEmitter } from '@angular/core';
 export class ColorPickerService {
   color: string = '';
   pureColor: string = '#ff0000';
-  updateColor = new EventEmitter<void>();
+  updateColor = new EventEmitter<string>();
   updatePureColor = new EventEmitter<void>();
   saveRecentColor = new EventEmitter<void>();
 
@@ -19,11 +19,12 @@ export class ColorPickerService {
     return this.pureColor;
   }
 
-  setColor(color) {
+  // setter is who set the color, default as ''
+  setColor(color, setter: string = 'normal') {
     var changed = this.color !== color
     this.color = color;
     if (changed)
-      this.updateColor.emit();
+      this.updateColor.emit(setter);
   }
 
   setPureColor(color) {

--- a/ng-devui-plus/shared/utils/color.ts
+++ b/ng-devui-plus/shared/utils/color.ts
@@ -140,6 +140,7 @@ function rgbToHex(r, g, b) {
 }
 
 function hexToRgb(hex) {
+  hex = hexColorSpread(hex)
   var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
   return result ? [
     parseInt(result[1], 16),
@@ -154,6 +155,20 @@ function sum(nums) {
     sum += nums[i]
   }
   return sum
+}
+
+/**
+ * Spread hex color. e.g. '#fff' => '#ffffff'
+ */
+function hexColorSpread(color: string) {
+  var colorArr = color.split('')
+  if (colorArr.length == 4) {
+    for (var i = 3; i > 0; i--) {
+      colorArr.splice(i, 0, colorArr[i])
+    }
+  }
+  color = colorArr.join('')
+  return color
 }
 
 export {


### PR DESCRIPTION
具体的修改列表如下：
- 使用service进行组件通信（数据和事件发布订阅）
  - 在取色盘上移动时，不改变purecolor，当输入框颜色变化时，改变panel pointer和slider pointer的位置，这都意味着需要做color setter的分类处理。
- 通过在html里把advanced-color-panel 放在basic-color前面解决了奇怪的top问题
- 清除的颜色在advanced的处理（默认显示个红色）
- 让 color pointer 拖到外面仍在边缘拖动，从而更加流畅